### PR TITLE
fixed issue with svgo npm package config

### DIFF
--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,15 +1,17 @@
 module.exports = {
 	plugins: [
 		{
+			name: 'removeScriptElement'
+		},
+		{
 			name: 'preset-default',
 			params: {
 				overrides: {
 					// manage plugins
 					removeViewBox: false,
-					removeUnknownsAndDefaults: false,
-					removeScriptElement: true
+					removeUnknownsAndDefaults: false
 				},
 			},
-		},
+		}
 	],
 };


### PR DESCRIPTION
There was an issue with the 'removeScriptElement' not being properly enabled in the 'svgs' NPM script. I have updated the config and tested it (added a script tag in an SVG file; it was removed with this new configuration).