### PR TITLE
fix: remove trailing slash from void html elems

### DIFF
--- a/web/amplify/advanced-components/accessible-autocomplete.html
+++ b/web/amplify/advanced-components/accessible-autocomplete.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Accessible auto-complete - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/cards.html
+++ b/web/amplify/advanced-components/cards.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Block link cards - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/carousel.html
+++ b/web/amplify/advanced-components/carousel.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Carousel - Amplify</title>
 
-    <link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+    <link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
 	<!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-    <link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+    <link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
     <script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/collapsibles.html
+++ b/web/amplify/advanced-components/collapsibles.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Collapsible containers - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/disclosure-widget.html
+++ b/web/amplify/advanced-components/disclosure-widget.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Disclosure widget - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/index.html
+++ b/web/amplify/advanced-components/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Advanced components - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/navigation/double-level-intro.html
+++ b/web/amplify/advanced-components/navigation/double-level-intro.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Demo: double-level navigation with intro text - Amplify</title>
 
-    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen"/>
+    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print"/>
+    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print">
 
     <script src="../../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/navigation/double-level.html
+++ b/web/amplify/advanced-components/navigation/double-level.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Demo: double-level navigation - Amplify</title>
 
-    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen"/>
+    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print"/>
+    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print">
 
     <script src="../../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/navigation/index.html
+++ b/web/amplify/advanced-components/navigation/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Advanced navigation - Amplify</title>
 
-    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen"/>
+    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print"/>
+    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print">
 
     <script src="../../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/navigation/single-level.html
+++ b/web/amplify/advanced-components/navigation/single-level.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Demo: single-level navigation - Amplify</title>
 
-    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen"/>
+    <link rel="stylesheet" href="../../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print"/>
+    <link rel="stylesheet" href="../../../dist/styles/print.css" media="print">
 
     <script src="../../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/advanced-components/sortable-tables.html
+++ b/web/amplify/advanced-components/sortable-tables.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Sortable-tables - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 	<script>

--- a/web/amplify/advanced-components/tabs.html
+++ b/web/amplify/advanced-components/tabs.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Tabbed sections - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/avatars.html
+++ b/web/amplify/core-components/avatars.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Avatars - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/breadcrumbs.html
+++ b/web/amplify/core-components/breadcrumbs.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Breadcrumbs - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/cards.html
+++ b/web/amplify/core-components/cards.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Simple cards - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/image-component.html
+++ b/web/amplify/core-components/image-component.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Image component - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 
@@ -99,7 +99,7 @@
 					</div>
 					<figure class="component component--image">
 						<div class="l-frame l-frame--16-9">
-							<img src="../../dist/images/jpg-cat-1.jpg" loading="lazy" alt="" />
+							<img src="../../dist/images/jpg-cat-1.jpg" loading="lazy" alt="">
 						</div>
 						<figcaption>
 							<p>The figcaption is not a replacement for the image's <code>alt</code> attribute. It should be used for providing relevant supporting content.</p>

--- a/web/amplify/core-components/index.html
+++ b/web/amplify/core-components/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Core components - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/main.html
+++ b/web/amplify/core-components/main.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Main - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/notes.html
+++ b/web/amplify/core-components/notes.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Notes - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/pagination.html
+++ b/web/amplify/core-components/pagination.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Pagination - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/progress-indicator.html
+++ b/web/amplify/core-components/progress-indicator.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Progress indicator - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/quote-component.html
+++ b/web/amplify/core-components/quote-component.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Quote component - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/search.html
+++ b/web/amplify/core-components/search.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Simple search form - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/shelves.html
+++ b/web/amplify/core-components/shelves.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Shelves - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/sticky-footer.html
+++ b/web/amplify/core-components/sticky-footer.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Sticky footer - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/tag-list.html
+++ b/web/amplify/core-components/tag-list.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Tag list - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/text-component.html
+++ b/web/amplify/core-components/text-component.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Text component - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/core-components/video.html
+++ b/web/amplify/core-components/video.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Video component - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/design/index.html
+++ b/web/amplify/design/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Design handover and standards - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/design/typography-test.html
+++ b/web/amplify/design/typography-test.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Typography test</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 
@@ -82,7 +82,7 @@
 			<h6>Heading 6</h6>
 			<h2>Horizontal rule</h2>
 			<p>You can use horizontal rules, like the one below, to add emphasis to section breaks on a page. These lines should be used sparingly as headings should usually provide enough division between sections for the reader.</p>
-			<hr/>
+			<hr>
 			<p>A <a href="https://en.wikipedia.org/wiki/Paragraph">paragraph</a> is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.</p>
 			<h2>Describing a paragraph H2</h2>
 			<p>A <a href="https://en.wikipedia.org/wiki/Paragraph">paragraph</a> is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.</p>

--- a/web/amplify/fundamentals/blockquotes.html
+++ b/web/amplify/fundamentals/blockquotes.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Blockquotes - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
 	<!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/breakpoints.html
+++ b/web/amplify/fundamentals/breakpoints.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Breakpoints - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/buttons-links.html
+++ b/web/amplify/fundamentals/buttons-links.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Buttons and links - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/colours.html
+++ b/web/amplify/fundamentals/colours.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Colours - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/details-summary.html
+++ b/web/amplify/fundamentals/details-summary.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Details and summary - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/flow-elements.html
+++ b/web/amplify/fundamentals/flow-elements.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Flow elements - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/form-errors.html
+++ b/web/amplify/fundamentals/form-errors.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Form error messages - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/forms.html
+++ b/web/amplify/fundamentals/forms.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Forms - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/hide-and-show.html
+++ b/web/amplify/fundamentals/hide-and-show.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Hide and show items inclusively - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/icons.html
+++ b/web/amplify/fundamentals/icons.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Icons - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/images.html
+++ b/web/amplify/fundamentals/images.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Images - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/index.html
+++ b/web/amplify/fundamentals/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Fundamentals - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/lists.html
+++ b/web/amplify/fundamentals/lists.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Lists - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/print-styles.html
+++ b/web/amplify/fundamentals/print-styles.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Print styles - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/skip-link.html
+++ b/web/amplify/fundamentals/skip-link.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Skip link - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/tables.html
+++ b/web/amplify/fundamentals/tables.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Tables - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/typography.html
+++ b/web/amplify/fundamentals/typography.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Typography - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/utility-classes.html
+++ b/web/amplify/fundamentals/utility-classes.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Utility classes - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/fundamentals/vertical-spacing.html
+++ b/web/amplify/fundamentals/vertical-spacing.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Vertical spacing - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/get-started/browser-support.html
+++ b/web/amplify/get-started/browser-support.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Browser support - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/get-started/css.html
+++ b/web/amplify/get-started/css.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>CSS - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/get-started/index.html
+++ b/web/amplify/get-started/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Get started - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/get-started/javascript.html
+++ b/web/amplify/get-started/javascript.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>JavaScript - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/index.html
+++ b/web/amplify/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Amplify</title>
 
-	<link rel="stylesheet" href="../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../dist/styles/print.css" media="print">
 
 	<script src="../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/box.html
+++ b/web/amplify/layout-helpers/box.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Box layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/center.html
+++ b/web/amplify/layout-helpers/center.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Center layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/cluster.html
+++ b/web/amplify/layout-helpers/cluster.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Cluster layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/cover.html
+++ b/web/amplify/layout-helpers/cover.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Cover layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/frame.html
+++ b/web/amplify/layout-helpers/frame.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Frame layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/index.html
+++ b/web/amplify/layout-helpers/index.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Layout helpers - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/sidebar.html
+++ b/web/amplify/layout-helpers/sidebar.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Sidebar layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/amplify/layout-helpers/switcher.html
+++ b/web/amplify/layout-helpers/switcher.html
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Switcher layout helper - Amplify</title>
 
-	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen"/>
+	<link rel="stylesheet" href="../../dist/styles/core.css" media="screen">
 
     <!--
 	Print (Edge doesn't apply to print otherwise)
@@ -20,7 +20,7 @@
 	only all and (min--moz-device-pixel-ratio:0) and (display-mode:browser), (min--moz-device-pixel-ratio:0) and (display-mode:fullscreen)
 	">
 
-	<link rel="stylesheet" href="../../dist/styles/print.css" media="print"/>
+	<link rel="stylesheet" href="../../dist/styles/print.css" media="print">
 
 	<script src="../../dist/js/libraries/fontfaceobserver.js"></script>
 

--- a/web/index.php
+++ b/web/index.php
@@ -2,12 +2,12 @@
 <html lang="en" class="no-js">
 
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>Website title</title>
 
-	<link rel="stylesheet" href="dist/styles/core.min.css" media="screen"/>
+	<link rel="stylesheet" href="dist/styles/core.min.css" media="screen">
 
 	<!--
     Print (Edge doesn't apply to print otherwise)
@@ -24,7 +24,7 @@
     only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)
 	">
 
-	<link rel="stylesheet" href="dist/styles/print.min.css" media="print"/>
+	<link rel="stylesheet" href="dist/styles/print.min.css" media="print">
 
 	<script src="dist/js/libraries/fontfaceobserver.js"></script>
 


### PR DESCRIPTION
As recommended when using the W3C HTML validator