### PR TITLE
fix: add width/height attributes to images

### DIFF
--- a/web/amplify/advanced-components/cards.html
+++ b/web/amplify/advanced-components/cards.html
@@ -105,7 +105,7 @@
 								<p>Examining the popularity of cat-related media content online.</p>
 							</div>
 							<div class="l-frame card__image">
-								<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+								<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 							</div>
 						</div>
 					</div>
@@ -118,7 +118,7 @@
 								<div class="button" aria-hidden="true">Read more</div>
 							</div>
 							<div class="l-frame card__image">
-								<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+								<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 							</div>
 						</div>
 					</div>
@@ -141,7 +141,7 @@
 								</ul>
 							</div>
 							<div class="l-frame card__image">
-								<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+								<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 							</div>
 						</div>
 					</div>

--- a/web/amplify/advanced-components/carousel.html
+++ b/web/amplify/advanced-components/carousel.html
@@ -99,17 +99,17 @@
                             <ul class="splide__list">
                                 <li class="splide__slide">
                                     <div class="l-frame">
-                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A brown tabby cat with green eyes faces the camera">
+                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A brown tabby cat with green eyes faces the camera" width="640" height="491">
                                     </div>
                                 </li>
                                 <li class="splide__slide">
                                     <div class="l-frame">
-                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A second copy of the tabby cat from slide 1">
+                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A second copy of the tabby cat from slide 1" width="640" height="491">
                                     </div>
                                 </li>
                                 <li class="splide__slide">
                                     <div class="l-frame">
-                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A third copy of the tabby cat from slide 1">
+                                        <img src="../../dist/images/jpg-cat-1.jpg" alt="A third copy of the tabby cat from slide 1" width="640" height="491">
                                     </div>
                                 </li>
                             </ul>

--- a/web/amplify/core-components/avatars.html
+++ b/web/amplify/core-components/avatars.html
@@ -98,7 +98,7 @@
 					</div>
 					<div class="component">
 						<div class="avatar">
-							<img alt src="https://www.w3.org/2006/05/u/1682ihk1hqqo-sm.jpg">
+							<img alt src="https://s3.studio24.net/wp-content/uploads/2018/09/Close-Simon-150x150.jpg" width="150" height="150">
 						</div>
 					</div>
 					<div class="component component--text">

--- a/web/amplify/core-components/cards.html
+++ b/web/amplify/core-components/cards.html
@@ -111,7 +111,7 @@
 								<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 							</div>
 							<div class="l-frame card__image">
-								<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+								<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 							</div>
 						</div>
 					</div>

--- a/web/amplify/core-components/image-component.html
+++ b/web/amplify/core-components/image-component.html
@@ -97,7 +97,7 @@
 					</div>
 					<figure class="component component--image">
 						<div class="l-frame">
-							<img src="../../dist/images/jpg-cat-1.jpg" loading="lazy" alt="">
+							<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" loading="lazy" alt="">
 						</div>
 						<figcaption>
 							<p>The figcaption is not a replacement for the image's <code>alt</code> attribute. It should be used for providing relevant supporting content.</p>

--- a/web/amplify/core-components/shelves.html
+++ b/web/amplify/core-components/shelves.html
@@ -115,7 +115,7 @@
 										<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 									</div>
 									<div class="l-frame card__image">
-										<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+										<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 									</div>
 								</div>
 							</li>
@@ -127,7 +127,7 @@
 										<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 									</div>
 									<div class="l-frame card__image">
-										<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+										<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 									</div>
 								</div>
 							</li>
@@ -139,7 +139,7 @@
 										<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 									</div>
 									<div class="l-frame card__image">
-										<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+										<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 									</div>
 								</div>
 							</li>
@@ -151,7 +151,7 @@
 										<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 									</div>
 									<div class="l-frame card__image">
-										<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+										<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 									</div>
 								</div>
 							</li>
@@ -163,7 +163,7 @@
 										<a class="button" href="https://en.wikipedia.org/wiki/Cats_and_the_Internet"><span class="visuallyhidden">Cats and the Internet:</span> Read more</a>
 									</div>
 									<div class="l-frame card__image">
-										<img src="../../dist/images/jpg-cat-1.jpg" alt="" loading="lazy">
+										<img src="../../dist/images/jpg-cat-1.jpg" width="640" height="491" alt="" loading="lazy">
 									</div>
 								</div>
 							</li>

--- a/web/amplify/layout-helpers/frame.html
+++ b/web/amplify/layout-helpers/frame.html
@@ -98,12 +98,12 @@
 					</div>
 					<div class="component">
 						<div class="l-frame">
-							<img src="../../dist/images/jpg-cat-1.jpg" alt>
+							<img src="../../dist/images/jpg-cat-1.jpg" alt width="640" height="491">
 						</div>
 					</div>
 					<div class="component">
 						<div class="l-frame" data-shape="circle">
-							<img src="../../dist/images/jpg-cat-1.jpg" alt>
+							<img src="../../dist/images/jpg-cat-1.jpg" alt width="640" height="491">
 						</div>
 					</div>
 					<div class="component component--text">

--- a/web/amplify/typography-test/index.html
+++ b/web/amplify/typography-test/index.html
@@ -437,11 +437,11 @@
 			</div>
 		</form>
 		<h2>Images, figures, pictures and videos</h2>
-		<p>Under no circumstances should you have an image without an <code>alt</code> attribute. At a minimum, it should be an empty value like this one. That should only be used for purely decorative images though. </p>
-		<img src="https://images.unsplash.com/photo-1579546929518-9e396f3cc809?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY4MjA3NzQ4Mg&ixlib=rb-4.0.3&q=80&w=1080" alt="">
+		<p>Under no circumstances should you have an image without an <code>alt</code> attribute. At a minimum, it should be an empty value like this one. That should only be used for purely decorative images though.</p>
+		<img src="https://images.unsplash.com/photo-1579546929518-9e396f3cc809?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY4MjA3NzQ4Mg&ixlib=rb-4.0.3&q=80&w=1080" width="1080" height="720" alt>
 		<h3>An image in a figure with a caption</h3>
 		<figure>
-			<img src="https://images.unsplash.com/photo-1696251143046-2d32fb985b59?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=4470&q=80" alt="A Tokyo street in the early evening dusk. The shot is from under a steel bridge where there is a store, lit up, which in turn, lights up the surrounding area.">
+			<img src="https://images.unsplash.com/photo-1696251143046-2d32fb985b59?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=4470&q=80" width="4470" height="2980" alt="A Tokyo street in the early evening dusk. The shot is from under a steel bridge where there is a store, lit up, which in turn, lights up the surrounding area.">
 			<figcaption>Tokyo, Japan, looking stunning in the early evening. By <a href="https://unsplash.com/@ayumikubo">ayumi kubo</a>
 			</figcaption>
 		</figure>
@@ -449,7 +449,7 @@
 		<picture>
 			<source srcset="https://images.unsplash.com/photo-1692946573219-2257a4a29cad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1500&h=1500&q=80" media="(min-width: 1500px)">
 			<source srcset="https://images.unsplash.com/photo-1692946573219-2257a4a29cad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=800&q=80" media="(orientation: portrait)">
-			<img src="https://images.unsplash.com/photo-1692946573219-2257a4a29cad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=500&h=500&q=80" alt="An above shot of some very green leaves">
+			<img src="https://images.unsplash.com/photo-1692946573219-2257a4a29cad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=500&h=500&q=80" width="500" height="500" alt="An above shot of some very green leaves">
 		</picture>
 		<h3>A video element</h3>
 		<video controls src="https://assets.codepen.io/174183/flower.mp4"></video>


### PR DESCRIPTION
Best practice to minimise cumulative layout shift and necessary when using `loading="lazy"`